### PR TITLE
Add sublime text plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ function stylelintTask() {
 One of the big advantages of Stylelint is that most of the major IDE's have a plugin that can help you write the code without the need to run Stylelint.
 
 - VScode has a very good plugin for Stylelint. Follow the [instructions on this article](https://kumardeepak.xyz/blog/stylelint-scss-and-visual-studio-code/) to help set it up.
-- Inteliji also has a plugin for [Stylelint](https://www.jetbrains.com/help/idea/using-stylelint-code-quality-tool.html#ws_stylelint_lint_your_code).
+- Intellij also has a plugin for [Stylelint](https://www.jetbrains.com/help/idea/using-stylelint-code-quality-tool.html#ws_stylelint_lint_your_code).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ One of the big advantages of Stylelint is that most of the major IDE's have a pl
 
 - VScode has a very good plugin for Stylelint. Follow the [instructions on this article](https://kumardeepak.xyz/blog/stylelint-scss-and-visual-studio-code/) to help set it up.
 - Intellij also has a plugin for [Stylelint](https://www.jetbrains.com/help/idea/using-stylelint-code-quality-tool.html#ws_stylelint_lint_your_code).
-- SublimeText can use the [SublimeLinter-stylielint plugin](https://github.com/SublimeLinter/SublimeLinter-stylelint).
+- SublimeText can use the [SublimeLinter-stylelint plugin](https://github.com/SublimeLinter/SublimeLinter-stylelint).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ One of the big advantages of Stylelint is that most of the major IDE's have a pl
 
 - VScode has a very good plugin for Stylelint. Follow the [instructions on this article](https://kumardeepak.xyz/blog/stylelint-scss-and-visual-studio-code/) to help set it up.
 - Intellij also has a plugin for [Stylelint](https://www.jetbrains.com/help/idea/using-stylelint-code-quality-tool.html#ws_stylelint_lint_your_code).
+- SublimeText can use the [SublimeLinter-stylielint plugin](https://github.com/SublimeLinter/SublimeLinter-stylelint).
 
 
 ## Contributing


### PR DESCRIPTION
Also for Sublime Text there are Stylelint plugins. I chose the most widespread (see https://packagecontrol.io/search/stylelint - [SublimeLinter-stylelint](https://packagecontrol.io/packages/SublimeLinter-stylelint) leads the ladder with 21k installs. So I added a link to the list of available plugins.

Additionally, I fixed a minor typo.